### PR TITLE
Create hist dataset only after run; tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    ; ignore Numba internal warnings about NumPy type aliases
+    ignore::DeprecationWarning:numba.core.types.*
+    ignore::DeprecationWarning:numba.core.ir_utils.*

--- a/tests/test_models_run.py
+++ b/tests/test_models_run.py
@@ -1,14 +1,35 @@
 """
-Test that the models run without error
+Test that the models run for a short time without error
 """
+import pytest
+
 import vorts
 
 
+NT = 10  # number of time steps to run for
+
+
 def test_model_f_default_runs():
-    m = vorts.Model_f(tracers=vorts.Tracers.randu(n=10))
+    m = vorts.Model_f(nt=NT)
+    assert m.int_scheme_name == "RK4"
+    m.run()
+
+
+def test_model_f_other_integ_runs():
+    m = vorts.Model_f(nt=NT, int_scheme_name="FT")
     m.run()
 
 
 def test_model_py_default_runs():
-    m = vorts.Model_py(int_scheme_name="scipy_DOP853")  # too many annoying Numba warnings currently
+    m = vorts.Model_py(nt=NT)  # too many annoying Numba warnings currently
+    assert m.int_scheme_name == "RK4"
+    m.run()
+
+
+@pytest.mark.parametrize(
+    "int_scheme_name",
+    [n for n in vorts.Model_py._allowed_int_scheme_names if n != "RK4"]
+)
+def test_model_py_other_integ_runs(int_scheme_name):
+    m = vorts.Model_py(nt=NT, int_scheme_name=int_scheme_name)
     m.run()

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,0 +1,18 @@
+"""
+Test that the plotting functions work without error
+"""
+import pytest
+
+import vorts
+
+
+# Run case to plot
+m = vorts.Model_py(tracers=vorts.Tracers.grid(7, 7)).run()
+
+
+@pytest.mark.parametrize(
+    "which",
+    ("vortons", "tracers", "poincare")
+)
+def test_plot_works_from_model(which):
+    m.plot(which)

--- a/vorts/model.py
+++ b/vorts/model.py
@@ -152,7 +152,7 @@ class ModelBase(abc.ABC):
                     "long_name": "Tracer mask",
                     "description": (
                         r"Vortons have nonzero $\Gamma$ values. "
-                        r"Tracers have no $\Gamma$. "
+                        r"Tracers have no $\Gamma$."
                     )
                 }),
             },

--- a/vorts/model.py
+++ b/vorts/model.py
@@ -152,7 +152,7 @@ class ModelBase(abc.ABC):
             },
             attrs={
                 "model_class": self.__class__.__name__,
-                "int_scheme_name": getattr(self, "int_scheme_name", ""),
+                "int_scheme_name": getattr(self, "int_scheme_name", "?"),
             },
         )
         return ds

--- a/vorts/model.py
+++ b/vorts/model.py
@@ -133,7 +133,7 @@ class ModelBase(abc.ABC):
                 "v": ("v", v, {
                     "long_name": "Vorton index",
                     "description": (
-                        "This includes true vortons (with nonzero $\Gamma$, coming first) "
+                        r"This includes true vortons (with nonzero $\Gamma$, coming first) "
                         r"and may also include tracers ($\Gamma = 0$, coming after)."
                     )
                 }),
@@ -408,6 +408,10 @@ class Model_f(ModelBase):
         for f in glob.glob('./out/*'):  # non-hidden files
             os.remove(f)
         self.oe = subprocess.check_output(cmd, stderr=subprocess.STDOUT)
+        # Note: could instead use `error stop` in the Fortran to get non-zero exit code and CalledProcessError
+        s_oe = str(self.oe, "utf-8")
+        if s_oe.startswith("STOP"):
+            raise Exception(f"the model stopped early, with message:\n{str(s_oe)}")
         os.chdir(cwd)
         # ^ hack for now, but could instead pass FORT_BASE_DIR into the Fortran program
         #   using vorts_sim_in.txt

--- a/vorts/plot.py
+++ b/vorts/plot.py
@@ -44,9 +44,8 @@ def plot_vorton_trajectories(ds, title="Vortons", ax=None, **kwargs):
     **kwargs
         Passed on to [`plt.subplots()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html)
     """
-    # Select vortons
-    iv = ds.G != 0  # TODO: move this to the ds creation in model
-    ds = ds.sel(v=iv)
+    # Select vortons only
+    ds = ds.isel(v=~ds.is_t)
 
     fig, ax = _maybe_new_fig(ax=ax, **kwargs)
 
@@ -79,9 +78,8 @@ def plot_tracer_trajectories(ds, title="Tracers", ax=None, **kwargs):
     **kwargs
         Passed on to [`plt.subplots()`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html)
     """
-    # Select tracers
-    it = ds.G == 0  # tracers boolean
-    ds = ds.sel(v=it)
+    # Select tracers only
+    ds = ds.isel(v=ds.is_t)
 
     fig, ax = _maybe_new_fig(ax=ax, **kwargs)
 
@@ -205,10 +203,9 @@ def plot_poincare(ds, *,
     # Subset data to approximate Poincare section
     ds = select_poincare_times(ds, iv_ref, **select_poincare_times_kwargs)
 
-    # Select tracers
-    it = ds.G == 0
-    ds_v0 = ds.sel(v=~it).isel(t=0)
-    ds = ds.sel(v=it)
+    # Select tracers and initial vortons
+    ds_v0 = ds.sel(v=~ds.is_t).isel(t=0)
+    ds = ds.sel(v=ds.is_t)
 
     fig, ax = _maybe_new_fig(ax=ax, **subplots_kwargs)
 

--- a/vorts/plot.py
+++ b/vorts/plot.py
@@ -95,6 +95,8 @@ def plot_tracer_trajectories(ds, title="Tracers", ax=None, **kwargs):
     _fig_post(fig, ax, title=title, frame="default")
 
 
+# TODO: optionally take averages of positions next to each other in time (with weights based on deltas)
+
 def select_poincare_times(ds, iv_ref=0, *, xtol=1e-2, ytol=1e-2):
     """From a model output dataset, extract data corresponding to times to use for the Poincaré section.
 

--- a/vorts/py/integ.py
+++ b/vorts/py/integ.py
@@ -122,7 +122,7 @@ def integrate_manual(
     if adapt_tstep:
         use_tqdm = False  # override this for now
 
-    nt = t_eval.size  # number of integration steps
+    nt = t_eval.size - 1  # number of integration steps
     nv = x0.size  # number of vortons
 
     # initial previous C val is C_0

--- a/vorts/py/integ.py
+++ b/vorts/py/integ.py
@@ -145,8 +145,10 @@ def integrate_manual(
         iter_l = tqdm_notebook(iter_l)
 
     # pre-allocate return arrays
-    xhist = np.empty((nv, nt))
+    xhist = np.empty((nv, nt+1))
     yhist = np.empty_like(xhist)
+    xhist[:,0] = x0
+    yhist[:,0] = y0
 
     # iterate over time index `l`
     x_lm1 = x0  # l-1 starts at 0
@@ -181,13 +183,13 @@ def integrate_manual(
             # step
             x_l, y_l = stepper(G, x_lm1, y_lm1, dt=dt0)
 
+        # store
+        xhist[:, l] = x_l
+        yhist[:, l] = y_l
+
         # new lm1 terms
         x_lm1 = x_l
         y_lm1 = y_l
-
-        # store
-        xhist[:, l-1] = x_lm1
-        yhist[:, l-1] = y_lm1
 
     return xhist, yhist
 


### PR DESCRIPTION
* instead of pre-allocating empty dataset before running and updating the values after, we create the dataset using the run's values after the run is complete
  - dataset has now a `is_t` tracer mask variable, for selecting vortons/tracers only. This way, plotting/post-proc routines don't need to do it.
* more run tests
  - all integration schemes, though not all Python tendency calculators included
  - now testing that default plots work as well
  - use `pytest.ini` to ignore the NumPy warnings inside Numba