### PR TITLE
Initial Julia implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+# Julia sysimage
+sys*.so
+
 # Julia full package manifest
 Manifest.toml
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 
+# Julia full package manifest
+Manifest.toml
+
 # built Fortran files
 vorts/f/src/*.o
 vorts/f/src/*.mod

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ include_package_data = true
 python_requires = >= 3.8
 install_requires =
     cycler
-    julia  # pyjulia
     makefun
     matplotlib
     numba
@@ -21,6 +20,11 @@ install_requires =
     xarray
 
 [options.extras_require]
+julia =
+    julia  # pyjulia
+    diffeqpy
+complete =
+    %(julia)s
 docs =
     pdoc3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ include_package_data = true
 python_requires = >= 3.8
 install_requires =
     cycler
+    julia  # pyjulia
     makefun
     matplotlib
     numba

--- a/vorts/__init__.py
+++ b/vorts/__init__.py
@@ -4,5 +4,5 @@ vorts -- point vortex models
 .. include:: ../README.md
 """
 from . import plot  # noqa: F401
-from .model import Model_f, Model_py  # noqa: F401
+from .model import Model_f, Model_jl, Model_py  # noqa: F401
 from .vortons import Tracers, Vortons  # noqa: F401

--- a/vorts/jl/Project.toml
+++ b/vorts/jl/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"

--- a/vorts/jl/Project.toml
+++ b/vorts/jl/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/vorts/jl/Project.toml
+++ b/vorts/jl/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
 PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/vorts/jl/Project.toml
+++ b/vorts/jl/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 DifferentialEquations = "0c46a032-eb83-5123-abaf-570d42b7fbaa"
+PackageCompiler = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d"

--- a/vorts/jl/README.md
+++ b/vorts/jl/README.md
@@ -1,2 +1,14 @@
-Follow the instructions [here](https://julialang.github.io/Pkg.jl/v1/environments/#Using-someone-else's-project)
-to create an environment based on the `Project.toml`.
+
+## Setup
+
+0. Install Julia
+
+1. Follow the instructions [here](https://julialang.github.io/Pkg.jl/v1/environments/#Using-someone-else's-project)
+   to create an environment based on the [`Project.toml`](./Project.toml).
+
+2. With [pyjulia](https://github.com/JuliaPy/pyjulia) installed (included in `vorts`'s deps), you can run
+   ```python
+   import julia; julia.install()
+   ```
+   to check that your Julia/Python installations are ready for pyjulia.
+   This will install [PyCall.jl](https://github.com/JuliaPy/PyCall.jl) in  your base Julia environment if you don't already have it.

--- a/vorts/jl/README.md
+++ b/vorts/jl/README.md
@@ -1,1 +1,2 @@
-Coming soon...
+Follow the instructions [here](https://julialang.github.io/Pkg.jl/v1/environments/#Using-someone-else's-project)
+to create an environment based on the `Project.toml`.

--- a/vorts/jl/compile.jl
+++ b/vorts/jl/compile.jl
@@ -1,13 +1,18 @@
-# Create a Julia sysimage for faster startup when calling from Py
-# Can take a few minutes and be 100s of MB
-
-using Pkg; Pkg.activate("./")
+# Create a Julia sysimage for faster startup
+#
+# The env should be activated when runinng:
+# julia --project=. compile.jl
+#
+# Note that it can take a few minutes and the sysimage can be 100s of MB
+#
+# To try it out:
+# julia --sysimage sys_vorts.so --project=. -e 'include(\"vorts.jl\"); main()'
 
 using PackageCompiler
 
 
 create_sysimage(
-    [:DifferentialEquations],#, :Plots],
+    [:DifferentialEquations, :Plots],
     sysimage_path="sys_vorts.so",
     precompile_execution_file="vorts.jl",
 )

--- a/vorts/jl/compile.jl
+++ b/vorts/jl/compile.jl
@@ -1,6 +1,6 @@
 # Create a Julia sysimage for faster startup
 #
-# The env should be activated when runinng:
+# The env should be activated when running:
 # julia --project=. compile.jl
 #
 # Note that it can take a few minutes and the sysimage can be 100s of MB

--- a/vorts/jl/compile.jl
+++ b/vorts/jl/compile.jl
@@ -1,0 +1,13 @@
+# Create a Julia sysimage for faster startup when calling from Py
+# Can take a few minutes and be 100s of MB
+
+using Pkg; Pkg.activate("./")
+
+using PackageCompiler
+
+
+create_sysimage(
+    [:DifferentialEquations],#, :Plots],
+    sysimage_path="sys_vorts.so",
+    precompile_execution_file="vorts.jl",
+)

--- a/vorts/jl/vorts.jl
+++ b/vorts/jl/vorts.jl
@@ -100,7 +100,13 @@ function plot_sol(sol)
 end
 
 
-# Test
-sol = integrate([0 1 ; 0 0.01; 0 -1], ones(3), 0.1, 5000)
-plot_sol(sol)
+# try it out
+function main()
+  sol = integrate([0 1 ; 0 0.01; 0 -1], ones(3), 0.1, 500)
+  plot_sol(sol)
+end
 
+
+if abspath(PROGRAM_FILE) == @__FILE__
+  main()
+end

--- a/vorts/jl/vorts.jl
+++ b/vorts/jl/vorts.jl
@@ -50,7 +50,20 @@ end
 
 # TODO: complex number formulation + benchmark
 
-"Integrate and return the solution object."
+
+"""
+    integrate(r₀, G, dt, nt; int_scheme_name)
+
+Integrate and return the solution object.
+
+# Arguments
+* `r₀`: initial positions, where each row is an ``xy`` coordinate pair
+* `G`: vector of ``\\Gamma`` values for each position
+* `dt`: time step that we want the output to have
+* `nt`: number of time steps taken from ``t=0``
+* `int_scheme_name`: string of a solver name, e.g., from the
+  [ODE solvers list](https://diffeq.sciml.ai/stable/solvers/ode_solve/)
+"""
 function integrate(r₀, G, dt, nt; int_scheme_name="Tsit5")
   # Inputs
   r₀ = permutedims(r₀)  # for Julia, we want coords as cols
@@ -65,10 +78,12 @@ function integrate(r₀, G, dt, nt; int_scheme_name="Tsit5")
   # Notes:
   # * with default settings, ends up using Tsit5 (`all(sol.alg_choice .== 1)` is true)
   # * might want to enable dense for Poincare purposes in the future (not compatible with `saveat`)
+  # * could consider using `dtmax=dt`
 
   # Note that `sol.u` is the solution, as a vec of arrays like r₀ (each r(t) is its own array)
   return sol
 end
+
 
 "Plot the solution on Julia side for testing."
 function plot_sol(sol)
@@ -83,6 +98,7 @@ function plot_sol(sol)
   plot!(;p_plot...)
   gui()
 end
+
 
 # Test
 sol = integrate([0 1 ; 0 0.01; 0 -1], ones(3), 0.1, 5000)

--- a/vorts/jl/vorts.jl
+++ b/vorts/jl/vorts.jl
@@ -63,8 +63,10 @@ Integrate and return the solution object.
 * `nt`: number of time steps taken from ``t=0``
 * `int_scheme_name`: string of a solver name, e.g., from the
   [ODE solvers list](https://diffeq.sciml.ai/stable/solvers/ode_solve/)
+* `ret_for`: for `"julia"`, return the solution object;
+  for `"python"`, return x and y arrays in (t, v) dim order
 """
-function integrate(r₀, G, dt, nt; int_scheme_name="Tsit5")
+function integrate(r₀, G, dt, nt; int_scheme_name="Tsit5", ret_for="julia")
   # Inputs
   r₀ = permutedims(r₀)  # for Julia, we want coords as cols
   @assert length(G) == size(r₀, 2)
@@ -81,7 +83,14 @@ function integrate(r₀, G, dt, nt; int_scheme_name="Tsit5")
   # * could consider using `dtmax=dt`
 
   # Note that `sol.u` is the solution, as a vec of arrays like r₀ (each r(t) is its own array)
-  return sol
+  if ret_for == "julia"
+    return sol
+  elseif ret_for == "python"
+    xy = reduce(vcat, sol.u)  # x0; y0; x1; y1; ...
+    return xy[1:2:end, :], xy[2:2:end, :]
+  else
+    throw(error("invalid `ret_for`"))
+  end
 end
 
 

--- a/vorts/jl/vorts.jl
+++ b/vorts/jl/vorts.jl
@@ -1,0 +1,79 @@
+"""
+Solving the vorts problem using [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl)
+"""
+# Note: pre-compiling DifferentialEquations takes *long* time (for Plots too!)
+using DifferentialEquations: ODEProblem, solve, Vern7
+using Plots
+
+
+"Pre-factor used for both the ``x`` and ``y`` tend calculations"
+const TEND_PRE = 1 / 2pi
+
+
+"Parameters used in the position tendency calculation"
+struct TendParams
+  G :: Vector{Float64}
+  # n_vortons :: Integer
+end
+
+
+# Note: `@benchmark` estimates only 2 allocs, but should try to improve speed / Julian-ify
+"""
+    tend!
+
+Update the position time tendency `dr`, with `dr` and `r` passed as arrays of size `(2, n)`.
+That is, each col is the ``xy`` position vector for a given vorton (or tracer).
+"""
+function tend!(dr, r, p::TendParams, t)
+  G = p.G
+  n = length(G)
+
+  # Compute tendencies for each vorton
+  for i ∈ 1:n
+
+    # Sum all contributions to the tendencies for vorton `i`
+    dr[1, i] = 0  # dxdt
+    dr[2, i] = 0  # dydt
+    for j ∈ 1:n
+      Gj = G[j]
+      (i == j || Gj == 0) && continue  # skip if same vorton or tracer
+
+      dx = r[1, i] - r[1, j]
+      dy = r[2, i] - r[2, j]
+      lij_sqd = dx^2 + dy^2
+
+      dr[1, i] += -TEND_PRE*Gj * dy/lij_sqd
+      dr[2, i] += TEND_PRE*Gj * dx/lij_sqd
+    end
+  end
+end
+
+# TODO: complex number formulation + benchmark
+
+
+# Set up problem inputs
+r₀ = [
+  0 3;
+  0 -0.1;
+  0 -3;
+]'  # coords as rows -> coords as cols
+G = [1, 5, 1]
+@assert length(G) == size(r₀, 2)
+p = TendParams(G)
+tspan = (0.0, 1e4)
+
+# Integrate
+prob = ODEProblem(tend!, r₀, tspan, p)
+sol = solve(prob)  # ends up using Tsit5 by default (`all(sol.alg_choice .== 1)` is true)
+# sol = solve(prob, Vern7())
+
+# Plot
+lims = (-5, 5)
+p_plot = (aspect_ratio=:equal, xlabel=raw"$x$", ylabel=raw"$y$", xlims=lims, ylims=lims)
+plot()
+for i ∈ 1:length(p.G)
+  # Column-major, so (1, 3) is first row, (1, 2) is first col
+  plot!(sol, vars=(2i-1, 2i), label="$i")
+end
+plot!(;p_plot...)
+gui()

--- a/vorts/model.py
+++ b/vorts/model.py
@@ -483,3 +483,148 @@ class Model_f(ModelBase):
             ps_file = FORT_BASE_DIR / "out/ps.txt"
             data = np.genfromtxt(ps_file, skip_header=1, skip_footer=sf)
             self.ps = data
+
+
+JL_BASE_DIR = Path(__file__).parent / "jl"
+
+
+class Model_jl(ModelBase):
+    """Interface to the Julia model, whose source code is in `vorts/jl/vorts.jl`.
+
+    .. note::
+       In this implementation we communicate with Julia using
+       [pyjulia](https://github.com/JuliaPy/pyjulia)
+    """
+
+    def __init__(
+        self,
+        vortons: Vortons = None,
+        tracers: Tracers = None,
+        *,
+        dt=0.1,
+        nt=1000,
+        # above are passed to base
+        int_scheme_name="Tsit5",
+    ):
+        r"""
+
+        Parameters
+        ----------
+        vortons : vorts.vortons.Vortons
+            default: equilateral triangle with inscribing circle radius of $1$ and all $G=1$.
+
+        tracers : vorts.vortons.Tracers
+            default: no tracers
+
+        dt : float
+            Time step $\delta t$ for the output.
+            Additionally, for the integrators, `dt` is used as the constant or maximum integration time step
+            depending on the integration scheme.
+        nt : int
+            Number of time steps to run (not including $t=0$).
+
+        int_scheme_name : str
+            Time integration scheme name. Any from the
+            [ODE solvers list](https://diffeq.sciml.ai/stable/solvers/ode_solve/)
+            are valid.
+
+        """
+        # call base initialization
+        super().__init__(vortons, tracers, dt=dt, nt=nt)
+
+        # other inputs
+        self.int_scheme_name = int_scheme_name
+
+    # pyjulia alone
+    def _run_pyjulia(self):
+        # Use our sysimage with DifferentialEquations (and our tend fn) pre-compiled
+        # (has to be done before importing any Julia modules)
+        # TODO: make this optional
+        # from julia import Julia
+        # jl = Julia(sysimage=str(JL_BASE_DIR / "sys_vorts.so"))
+
+        # For some reason it doesn't work the first time on Windows (can't find PyCall)
+        # but will work if we just do it again...
+        import julia
+
+        try:
+            from julia import Base, Main, Pkg
+        except julia.core.JuliaError:
+            from julia import Base, Main, Pkg
+
+        # Load our code (with `.eval`)
+        # jl.eval(f'using Pkg; Pkg.activate("{JL_BASE_DIR.as_posix()}")')
+        # jl.eval(f'include("{(JL_BASE_DIR / "vorts.jl").as_posix()}")')
+        # jl.eval('println("vorts.jl has been loaded!")')
+
+        # Load our code
+        Base.println("Initial env status:")
+        Pkg.status()
+        Pkg.activate(JL_BASE_DIR.as_posix())
+        Pkg.status()
+        Main.include((JL_BASE_DIR / "vorts.jl").as_posix())
+        Base.println("vorts.jl has been loaded!")
+
+        # Run by calling `integrate` from `vorts.jl`
+        x, y = Main.integrate(
+            self._vt0.state_mat,
+            self._vt0.G,
+            self.dt,
+            self.nt,
+            int_scheme_name=self.int_scheme_name,
+            ret_for="python",
+        )
+
+        # Set output dataset
+        self.hist = self._res_to_xr(x, y)
+
+    # pyjulia + diffeqpy
+    def _run_diffeqpy(self):
+        # With Linux Conda, pyjulia complained that libpython was statically linked and said to do this:
+        # from julia import Julia
+        # jl = Julia(compiled_modules=False)
+
+        import julia
+
+        try:
+            from julia import Main, Pkg
+        except julia.core.JuliaError:
+            from julia import Main, Pkg
+
+        Pkg.activate(JL_BASE_DIR.as_posix())
+        Pkg.status()
+
+        # `ode` from the readme doesn't work yet in stable (would have to install from GH)
+        # This one would also take two tries if we hadn't already done the above import
+        from diffeqpy import de
+
+        # Add the code with the tendency function
+        Main.include((JL_BASE_DIR / "vorts.jl").as_posix())
+
+        # Set up our inputs
+        nt = self.nt
+        dt = self.dt
+        vt0 = self._vt0
+        r0 = vt0.state_mat.T  # note transpose!
+        tspan = (0, dt * nt)
+        p = Main.TendParams(vt0.G)
+        solver = getattr(de, self.int_scheme_name)()
+
+        prob = de.ODEProblem(Main.tend_b, r0, tspan, p)
+        sol = de.solve(prob, solver, saveat=np.arange(0, nt + 1) * dt)
+
+        # Set output dataset
+        x = np.empty((self.nt + 1, vt0.n))
+        y = np.empty_like(x)
+        assert len(sol.u) == nt + 1
+        assert sol.u[0].shape == (2, vt0.n)
+        for i in range(len(sol.u)):
+            x[i, :] = sol.u[i][0, :]
+            y[i, :] = sol.u[i][1, :]
+
+        self.hist = self._res_to_xr(x, y)
+
+    # later will allow setting which runner to use
+    def _run(self):
+        self._run_pyjulia()
+        # self._run_diffeqpy()


### PR DESCRIPTION
The vorts problem is easy with [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl). No problems when running on the Julia side, but had some issues when calling from Python using [pyjulia](https://github.com/JuliaPy/pyjulia). On Windows I am getting the error I mentioned at https://github.com/SciML/diffeqpy/issues/88. On Linux, it works with `Julia(compiled_modules=False)` (from [this tip](https://pyjulia.readthedocs.io/en/latest/troubleshooting.html#turn-off-compilation-cache)), but this makes it much slower to start. I got better startup times (~ 10 s) by following [this other tip](https://pyjulia.readthedocs.io/en/latest/troubleshooting.html#ultimate-fix-build-your-own-python) and doing an `--enable-shared` Python build and additionally using a Julia sysimage created using [`PackageCompiler`](https://github.com/JuliaLang/PackageCompiler.jl).

Later will add more options on the Julia side.