### PR TITLE
Plot methods

### DIFF
--- a/examples/f_simple.py
+++ b/examples/f_simple.py
@@ -49,7 +49,7 @@ m.run()
 
 # %% plot results
 m.plot()  # vortons are stationary!
-m.plot("tracers")
+m.plot.tracers()
 
 
 # %% [markdown]
@@ -58,4 +58,4 @@ m.plot("tracers")
 # Note that in rotating cases, `dt=0.005, nt=2e6` would give a better Poincare section, but we would only want to use this with `write_ps` only to avoid writing large tracer files. And, on the usual Binder, a longer run than what we have set would use too much memory and fail.
 
 # %%
-m.plot("poincare", c=["teal", "tomato"])
+m.plot.poincare(c=["teal", "tomato"])

--- a/examples/poincare.py
+++ b/examples/poincare.py
@@ -49,19 +49,19 @@ m = vorts.Model_py(
 
 # %%
 shared = dict(figsize=(6, 6), xtol=0.02, ytol=0.02, title=None)
-m.plot("poincare", ms=2, **shared)
+m.plot.poincare(ms=2, **shared)
 
 # %% [markdown]
 # We can add vortons to the plot to spice it up a bit (like the one shown in the readme).
 
 # %%
-m.plot("poincare", ms=2, plot_vortons=True, **shared)
+m.plot.poincare(ms=2, plot_vortons=True, **shared)
 
 # %% [markdown]
 # ### Color cycling
 
 # %%
-m.plot("poincare", ms=2.5, alpha=0.8, c=["g", "b"], **shared)
+m.plot.poincare(ms=2.5, alpha=0.8, c=["g", "b"], **shared)
 
 # %% [markdown]
 # ### Color, marker size, and marker alpha cycling
@@ -72,8 +72,7 @@ m.plot("poincare", ms=2.5, alpha=0.8, c=["g", "b"], **shared)
 fig, axs = plt.subplots(1, 2, figsize=(12, 6))
 
 for ax, cycle_by in zip(axs.flat, ["vorton", "time"]):
-    m.plot(
-        "poincare",
+    m.plot.poincare(
         ms=[1, 2, 4],
         c=plt.cm.rainbow(np.linspace(0, 1, 30)),
         alpha=[0.6, 0.85],

--- a/examples/py_simple.py
+++ b/examples/py_simple.py
@@ -66,7 +66,7 @@ m.run()
 m.plot()  # vortons by default
 
 # %%
-m.plot("tracers")
+m.plot.tracers()
 
 # %% [markdown]
 # ## Interactive, examining impact of options

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -11,4 +11,4 @@ m = vorts.Model_py(tracers=vorts.Tracers.grid(7, 7)).run()
 
 @pytest.mark.parametrize("which", ("vortons", "tracers", "poincare"))
 def test_plot_works_from_model(which):
-    m.plot(which)
+    getattr(m.plot, which)()

--- a/vorts/model.py
+++ b/vorts/model.py
@@ -15,7 +15,7 @@ from pathlib import Path
 import numpy as np
 import xarray as xr
 
-from .plot import plot_poincare, plot_tracer_trajectories, plot_vorton_trajectories
+from .plot import _PlotMethods
 from .py import MANUAL_STEPPERS, SCIPY_METHODS, integrate_manual, integrate_scipy
 from .vortons import Tracers, Vortons
 
@@ -83,6 +83,9 @@ class ModelBase(abc.ABC):
         # initially, the model hasn't been run
         self._has_run = False
 
+        # attach _PlotMethods instance
+        self.plot = _PlotMethods(self)
+
     @abc.abstractmethod
     def _run(self):
         """The `_run` method in concrete classes should:
@@ -102,26 +105,6 @@ class ModelBase(abc.ABC):
         # TODO: with hist having been updated (presumably), update vortons?
 
         return self
-
-    # might be better to use _plot_methods dict of name: function
-    # so that certain models could extend the options
-    def plot(self, which="vortons", **kwargs):
-        """Plot results stored in the history data set `hist`.
-
-        `**kwargs` are passed through to the corresponding plotting function
-        (see `vorts.plot`).
-        """
-        if not self._has_run:
-            raise Exception("The model has not yet been run.")
-
-        if which == "vortons":
-            plot_vorton_trajectories(self.hist, **kwargs)
-        elif which == "tracers":
-            plot_tracer_trajectories(self.hist, **kwargs)
-        elif which == "poincare":
-            plot_poincare(self.hist, **kwargs)
-        else:
-            raise NotImplementedError(f"which={which!r}")
 
     def _res_to_xr(self, xhist, yhist):
         """Take full trajectory histories `xhist` and `yhist`


### PR DESCRIPTION
* Give the model a `_PlotMethods` object, like in xarray/pandas, so that we can quickly `.plot()`, or `.plot.{name}()` to use plot `name`
  - `.plot()` worked before, but without the correct signature and no useful docstring. Now we have both of those (although may want to scrub `ds` from the parameters list of the docstring)